### PR TITLE
feat: add errorCallback param to genericFetchFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.1.19-nullsafety
+
+- feat: add errorCallback param to genericFetchFunction
+
 ### 0.1.18-nullsafety
 
 - chore: remove SILException

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Release](https://img.shields.io/badge/PreRelease-^0.1.18-success.svg?style=for-the-badge)](https://shields.io/)
+[![Release](https://img.shields.io/badge/PreRelease-^0.1.19-success.svg?style=for-the-badge)](https://shields.io/)
 [![Maintained](https://img.shields.io/badge/Maintained-Actively-informational.svg?style=for-the-badge)](https://shields.io/)
 
 # misc_utilities
@@ -23,7 +23,7 @@ This will add a line like this to your package's pubspec.yaml (and run an implic
 
 ```dart
 dependencies:
-  misc_utilities: ^0.1.18-nullsafety
+  misc_utilities: ^0.1.19-nullsafety
 ```
 
 Alternatively, your editor might support flutter pub get. Check the docs for your editor to learn more.

--- a/lib/src/misc.dart
+++ b/lib/src/misc.dart
@@ -354,7 +354,7 @@ String? parseError(Map<String, dynamic>? body) {
   return null;
 }
 
-///[Generic Fetch Function]
+/// [Generic Fetch Function]
 /// a generic fetch function for fetching all the problems, allergies
 /// medications, tests and diagnoses for the current patient
 /// in an episode
@@ -370,6 +370,7 @@ Future<dynamic> genericFetchFunction({
   required String queryString,
   required Map<String, dynamic> variables,
   required String logTitle,
+  Function? errorCallback,
   String? logDescription,
 }) async {
   // indicate processing is ongoing
@@ -399,6 +400,9 @@ Future<dynamic> genericFetchFunction({
 
   //check first for errors
   if (error != null) {
+    if (errorCallback != null) {
+      errorCallback();
+    }
     return streamController
         .addError(<String, dynamic>{'error': _client.parseError(payLoad)});
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: misc_utilities
 description: Collection of shared utility functions
-version: 0.1.18-nullsafety
+version: 0.1.19-nullsafety
 homepage: https://github.com/savannahghi/misc_utilities
 repository: https://github.com/savannahghi/misc_utilities
 issue_tracker: https://github.com/savannahghi/misc_utilities/issues

--- a/test/widget_tests/misc_test.dart
+++ b/test/widget_tests/misc_test.dart
@@ -376,6 +376,7 @@ void main() {
                     key: const Key('fetch_data'),
                     onPressed: () async {
                       await genericFetchFunction(
+                          errorCallback: () {},
                           streamController: _streamController,
                           context: context,
                           queryString: fakeQuery,


### PR DESCRIPTION
- Apps need to provide an errorCallback to genericFetchFunction which is executed when the response has an error